### PR TITLE
Function Disable & Reveal integrated in Networking 

### DIFF
--- a/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/GameLogicClient.java
+++ b/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/GameLogicClient.java
@@ -135,10 +135,15 @@ public class GameLogicClient extends GameLogic implements NetworkListener {
 
 				if(currentPlayerID == getDevices().getPlayer(getGameSettings().getPlayerName()).getId()){
 					activity.setDiceEnabled(true);
+					activity.setRevealEnabled(false);
+					activity.setSensorOn(true);
 				} else {
 					activity.setDiceEnabled(false);
+					activity.setRevealEnabled(true);
+					activity.setSensorOn(false);
 				}
 			}
+
 
 		} else {
 			Log.w(TAG, "Received unknown message from host.");

--- a/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/GameLogicClient.java
+++ b/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/GameLogicClient.java
@@ -1,6 +1,7 @@
 package com.vintagetechnologies.menschaergeredichnicht;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
 import android.widget.Toast;
@@ -112,12 +113,16 @@ public class GameLogicClient extends GameLogic implements NetworkListener {
 			} else if(TAG_PLAYER_HAS_CHEATED.equals(tag)){
 				//wird vom Host empfangen wenn Spieler aufdeckt?!
 				boolean hasCheated = Boolean.parseBoolean(value);
-				/*
+				Context context = getActivity().getApplicationContext();
+
 				//TODO: make right..
-				Toast.makeText(getApplicationContext(),
-						(hasCheated ? R.string.Eswurdegeschummelt : R.string.EswurdeNichtgeschummelt),
-						Toast.LENGTH_LONG).show();
-				*/
+				if(hasCheated) {
+					Toast.makeText(context, "Das Schummeln wurde enttarnt, Schummler stetzt nächste Runde aus", Toast.LENGTH_LONG).show();
+				}else{
+					Toast.makeText(context, "Es wurde falsch verdächtigt, verdacht äußernder setzt nächste Runde aus", Toast.LENGTH_LONG).show();
+				}
+
+
 			} else if(TAG_CLIENT_PLAYER_NAME.equals(tag)) {	// if hosts send the name of a client
 
 				DeviceList deviceList = getDevices();

--- a/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/GameLogicClient.java
+++ b/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/GameLogicClient.java
@@ -110,7 +110,14 @@ public class GameLogicClient extends GameLogic implements NetworkListener {
 				hostDevice.setName(value);
 
 			} else if(TAG_PLAYER_HAS_CHEATED.equals(tag)){
-
+				//wird vom Host empfangen wenn Spieler aufdeckt?!
+				boolean hasCheated = Boolean.parseBoolean(value);
+				/*
+				//TODO: make right..
+				Toast.makeText(getApplicationContext(),
+						(hasCheated ? R.string.Eswurdegeschummelt : R.string.EswurdeNichtgeschummelt),
+						Toast.LENGTH_LONG).show();
+				*/
 			} else if(TAG_CLIENT_PLAYER_NAME.equals(tag)) {	// if hosts send the name of a client
 
 				DeviceList deviceList = getDevices();
@@ -127,11 +134,16 @@ public class GameLogicClient extends GameLogic implements NetworkListener {
 				activity.setStatus(value);
 
 			} else if(TAG_CURRENT_PLAYER.equals(tag)) {
+				//Wird das bei Spielerwechsel aufgerufen und an alle geschickt???
 
 				Spieloberflaeche activity = (Spieloberflaeche) getActivity();
 
 				// network id of the players who's turn it is.
 				int currentPlayerID = Integer.parseInt(value);
+
+				//Currentplayer startet bei "null" als nicht Cheater.
+				Player currentPlayer = ActualGame.getInstance().getGameLogic().getCurrentPlayer();
+				currentPlayer.getSchummeln().setPlayerCheating(false);
 
 				if(currentPlayerID == getDevices().getPlayer(getGameSettings().getPlayerName()).getId()){
 					activity.setDiceEnabled(true);

--- a/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/GameLogicClient.java
+++ b/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/GameLogicClient.java
@@ -152,9 +152,9 @@ public class GameLogicClient extends GameLogic implements NetworkListener {
 				currentPlayer.getSchummeln().informHost(false); //Damit der Host auch weiß, dass (noch) nicht geschummelt wurde.
 
 				if(currentPlayerID == getDevices().getPlayer(getGameSettings().getPlayerName()).getId()){
-					activity.setDiceEnabled(true);
-					activity.setRevealEnabled(false);
-					activity.setSensorOn(true);
+					activity.setDiceEnabled(true); //Würfeln
+					activity.setRevealEnabled(false);  //Aufdecken
+					activity.setSensorOn(true); //Schummeln und Würfeln durch Schütteln
 				} else {
 					activity.setDiceEnabled(false);
 					activity.setRevealEnabled(true);

--- a/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/GameLogicClient.java
+++ b/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/GameLogicClient.java
@@ -148,7 +148,8 @@ public class GameLogicClient extends GameLogic implements NetworkListener {
 
 				//Currentplayer startet bei "null" als nicht Cheater.
 				Player currentPlayer = ActualGame.getInstance().getGameLogic().getCurrentPlayer();
-				currentPlayer.getSchummeln().setPlayerCheating(false);
+				currentPlayer.getSchummeln().setPlayerCheating(false); //Damit der Würfel weiß, dass noch nicht geschummelt wurde.
+				currentPlayer.getSchummeln().informHost(false); //Damit der Host auch weiß, dass (noch) nicht geschummelt wurde.
 
 				if(currentPlayerID == getDevices().getPlayer(getGameSettings().getPlayerName()).getId()){
 					activity.setDiceEnabled(true);

--- a/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/GameLogicHost.java
+++ b/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/GameLogicHost.java
@@ -237,9 +237,10 @@ public class GameLogicHost extends GameLogic implements NetworkListener {
 				currentPlayer.getSchummeln().setPlayerCheating(hasCheated);
 
 				//Soll das an alle geschickt werden? Wird nur benötigt zum Aufdecken, also braucht eigentlich nur der Host..
+				//! Wird nur in der Aufdeck methode an alle geschickt!! (um zu verraten ob player gecheated hat oder nicht)
 
 
-				// send changes to others
+				//send changes to others
 				//GameSynchronisation.synchronize();
 
 			} else if(TAG_REVEAL.equals(tag)){	// a player clicked "aufdecken"

--- a/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/GameLogicHost.java
+++ b/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/GameLogicHost.java
@@ -232,19 +232,12 @@ public class GameLogicHost extends GameLogic implements NetworkListener {
 
 				boolean hasCheated = Boolean.parseBoolean(value);
 
-				if(hasCheated){
-					// display who has to skip
+				//Jetziger Spieler wird als (nicht) Cheater makiert
+				Player currentPlayer = ActualGame.getInstance().getGameLogic().getCurrentPlayer();
+				currentPlayer.getSchummeln().setPlayerCheating(hasCheated);
 
-					/*
-					Toast.makeText(getActivity().getApplicationContext(),
-							playerName + " hat geschummelt und muss aussetzen!",
-							Toast.LENGTH_LONG).show();
-					*/
-				}
+				//Soll das an alle geschickt werden? Wird nur benötigt zum Aufdecken, also braucht eigentlich nur der Host..
 
-				// TODO: implement
-				// set player cheating/or not
-				//ActualGame.getInstance().getPlayerByName(clientDevice.getName()).getSchummeln().setPlayerCheating(hasCheated);
 
 				// send changes to others
 				//GameSynchronisation.synchronize();
@@ -254,10 +247,6 @@ public class GameLogicHost extends GameLogic implements NetworkListener {
 				// check if current player has cheated!
 				Player currentPlayer = ActualGame.getInstance().getGameLogic().getCurrentPlayer();
 				boolean isCheating = currentPlayer.getSchummeln().isPlayerCheating();
-
-				// send to others if player has cheated, just to display informations
-				sendToAllClientDevices(TAG_PLAYER_HAS_CHEATED + MESSAGE_DELIMITER + String.valueOf(isCheating));
-
 				currentPlayer.setHasToSkip(isCheating);
 
 				// player who clicked "aufdecken"
@@ -265,8 +254,13 @@ public class GameLogicHost extends GameLogic implements NetworkListener {
 				Player revealer = ActualGame.getInstance().getGameLogic().getPlayerByName(revealerName);
 				revealer.setHasToSkip(!isCheating);
 
-				GameSynchronisation.synchronize();
+                // send to others if player has cheated, just to display informations
+				sendToAllClientDevices(TAG_PLAYER_HAS_CHEATED + MESSAGE_DELIMITER + String.valueOf(isCheating));
 
+				// CurrentPlayer wurde als Cheater erkannt..kann wieder auf false gesetz werden?! - wenn noch jemand aufdeckt is er selbst schuld und muss aussetzen
+				currentPlayer.getSchummeln().setPlayerCheating(false);
+
+				GameSynchronisation.synchronize();
 
 			}else {
 			Log.w(TAG, String.format("Received unknown message '%s' from player '%s'", object, clientDevice.getName()));

--- a/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/GameLogicHost.java
+++ b/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/GameLogicHost.java
@@ -267,11 +267,10 @@ public class GameLogicHost extends GameLogic implements NetworkListener {
 
 				GameSynchronisation.synchronize();
 
-			}
 
-
-		}else {
+			}else {
 			Log.w(TAG, String.format("Received unknown message '%s' from player '%s'", object, clientDevice.getName()));
+			}
 		}
 	}
 

--- a/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/Spieloberflaeche.java
+++ b/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/Spieloberflaeche.java
@@ -554,6 +554,7 @@ public class Spieloberflaeche extends AppCompatActivity implements SensorEventLi
                 if (Lichtwert <= 10) {
                     //state.setText("Schummeln: " + true);  //Test
                     Schummeln.setPlayerCheating(true);
+                    Schummeln.informHost(true);
                 }
 
             }

--- a/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/Spieloberflaeche.java
+++ b/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/Spieloberflaeche.java
@@ -50,8 +50,6 @@ import static com.vintagetechnologies.menschaergeredichnicht.networking.Network.
 
 public class Spieloberflaeche extends AppCompatActivity implements SensorEventListener {
 
-    // toDO: alle Spielfunktionen ect. hinzufügen
-
     private GameLogic gameLogic;
     private GameSettings gameSettings;
 
@@ -222,7 +220,6 @@ public class Spieloberflaeche extends AppCompatActivity implements SensorEventLi
 		}
 
         //jetzt kann durch erneutes schütteln wieder ein Würfeln ausgelöst werden.
-        //TODo: Anpassen an wie oft darf man würfeln. erst wenn neuer zug erlaubt ist für den Spieler auf true setzen.
         shook = false;
     }
 
@@ -314,9 +311,8 @@ public class Spieloberflaeche extends AppCompatActivity implements SensorEventLi
         ShakeSensor = SM.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
         SM.registerListener(this, ShakeSensor, SensorManager.SENSOR_DELAY_GAME);
 
-        // ToDo: Disable wenn Spieler gerade spielt
         // aktuell spielender Spieler wird des Schummelns verdächtigt
-        btnAufdecken = (ImageButton) (findViewById(R.id.imageButton_aufdecken)); // ToDO: Disable für gerade spielenden Spieler
+        btnAufdecken = (ImageButton) (findViewById(R.id.imageButton_aufdecken));
         btnAufdecken.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -324,7 +320,7 @@ public class Spieloberflaeche extends AppCompatActivity implements SensorEventLi
             }
         });
 
-        btnWuerfel = (ImageButton) (findViewById(R.id.imageButton_wuerfel)); //ToDo: Disable für Spieler die nicht am Zug sind
+        btnWuerfel = (ImageButton) (findViewById(R.id.imageButton_wuerfel));
         btnWuerfel.setEnabled(true);
 
         RealDice.get();
@@ -445,6 +441,7 @@ public class Spieloberflaeche extends AppCompatActivity implements SensorEventLi
 			// TODO: implement
 
         } else {
+
             GameLogicClient gameLogicClient = (GameLogicClient) gameLogic;
             gameLogicClient.sendToHost(TAG_REVEAL);
         }
@@ -558,7 +555,7 @@ public class Spieloberflaeche extends AppCompatActivity implements SensorEventLi
                     //state.setText("Schummeln: " + true);  //Test
                     Schummeln.setPlayerCheating(true);
                 }
-                //Kein else da nach spieler wechsel allgemein auf false zurückgesetz wird
+
             }
 
         }
@@ -589,6 +586,10 @@ public class Spieloberflaeche extends AppCompatActivity implements SensorEventLi
 			((GameLogicHost) gameLogic).sendToAllClientDevices(TAG_STATUS_MESSAGE + MESSAGE_DELIMITER + status);
     }
 
+    /**
+     * Getting updated with the change auf the player status to currentPlayer.
+     * @param enabled
+     */
     //Sensors are only used when player == currentPlayer
     public void setSensorOn(boolean enabled) {
         sensorOn = enabled;

--- a/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/Spieloberflaeche.java
+++ b/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/Spieloberflaeche.java
@@ -97,6 +97,7 @@ public class Spieloberflaeche extends AppCompatActivity implements SensorEventLi
      * UI Updates finden auf dem Main Thread statt
      */
     private void btnWuerfelClicked() {
+
         // ui elementes must be updated on main thread:
         runOnUiThread(new Runnable() {
             public void run() {
@@ -501,62 +502,65 @@ public class Spieloberflaeche extends AppCompatActivity implements SensorEventLi
     }
 
 
+    boolean sensorOn = true;
     /**
-     * ToDO: Sollte nur aktiviert sein wenn Spieler aktuell spielt.
-     * ToDO: Schummelfunktion sollte bei jedem Spielerwechsel auf false gesetzt werden.
-     * Da auf änderung reagiert, dürfte nicht wenn bevor man am zug ist verdunkelt wird nicht reagiert werden.
+     * The Sensor reactions for shaking the Dice and for Cheating
      */
     @Override
     public void onSensorChanged(SensorEvent event) {
-        /**
-         * SchüttelSensor: löst Würfeln aus. Nur einmal dann wird shook auf false gesetzt. (nach dem Würfeln wieder auf true)
-         */
+        //If Player == Currentplayer sensor is true and you can shake and cheat.
+        if (sensorOn) {
 
-        if (event.sensor.getType() == Sensor.TYPE_ACCELEROMETER) {
-            //TODo ist das mit shook sinnvoll?! Gibt es bessere lösung
-            if (!shook) {
-                long curTime = System.currentTimeMillis();
-                // only allow one update every 100ms.
-                if ((curTime - lastUpdate) > 100) {
-                    long diffTime = (curTime - lastUpdate);
-                    lastUpdate = curTime;
+            /**
+             * SchüttelSensor: löst Würfeln aus. Nur einmal dann wird shook auf false gesetzt. (nach dem Würfeln wieder auf true)
+             */
+            if (event.sensor.getType() == Sensor.TYPE_ACCELEROMETER) {
+                //Shook wird nach dem würfeln wieder auf false gesetzt. bzw wenn dich der Spieler status ändert geändert.
+                if (!shook) {
+                    long curTime = System.currentTimeMillis();
+                    // only allow one update every 100ms.
+                    if ((curTime - lastUpdate) > 100) {
+                        long diffTime = (curTime - lastUpdate);
+                        lastUpdate = curTime;
 
-                    float x = event.values[0];
-                    float y = event.values[1];
-                    float z = event.values[2];
+                        float x = event.values[0];
+                        float y = event.values[1];
+                        float z = event.values[2];
 
-                    float speed = Math.abs(x + y + z - last_x - last_y - last_z) / diffTime * 10000;
+                        float speed = Math.abs(x + y + z - last_x - last_y - last_z) / diffTime * 10000;
 
-                    if (speed > SHAKE_THRESHOLD) {
-                        shook = true;
-                        Runnable myRunnable = new Runnable() {
-                            @Override
-                            public void run() {
-                                btnWuerfelClicked();
-                            }
-                        };
-                        new Thread(myRunnable).start();
+                        if (speed > SHAKE_THRESHOLD) {
+                            shook = true;
+                            Runnable myRunnable = new Runnable() {
+                                @Override
+                                public void run() {
+                                    btnWuerfelClicked();
+                                }
+                            };
+                            new Thread(myRunnable).start();
+                        }
+
+                        last_x = x;
+                        last_y = y;
+                        last_z = z;
                     }
-
-                    last_x = x;
-                    last_y = y;
-                    last_z = z;
                 }
             }
-        }
 
 
-        /** Für Licht
-         * Reagiert bei änderung wird entsprechender Wert zwischen 0.0 und 40000 angegeben.
-         * wenn schummel funktion ab Dunkel sich einschaltet. Annahme Dunkel ab 1000.
-         */
-        if (event.sensor.getType() == Sensor.TYPE_LIGHT) {
-            float Lichtwert = event.values[0];
-            if (Lichtwert <= 10) {
-                //state.setText("Schummeln: " + true);  //Test
-                Schummeln.setPlayerCheating(true);
+            /** Für Licht
+             * Reagiert bei änderung wird entsprechender Wert zwischen 0.0 und 40000 angegeben.
+             * wenn schummel funktion ab Dunkel sich einschaltet. Annahme Dunkel ab 1000.
+             */
+            if (event.sensor.getType() == Sensor.TYPE_LIGHT) {
+                float Lichtwert = event.values[0];
+                if (Lichtwert <= 10) {
+                    //state.setText("Schummeln: " + true);  //Test
+                    Schummeln.setPlayerCheating(true);
+                }
+                //Kein else da nach spieler wechsel allgemein auf false zurückgesetz wird
             }
-            //Kein else da nach spieler wechsel allgemein auf false zurückgesetz wird
+
         }
     }
 
@@ -585,7 +589,14 @@ public class Spieloberflaeche extends AppCompatActivity implements SensorEventLi
 			((GameLogicHost) gameLogic).sendToAllClientDevices(TAG_STATUS_MESSAGE + MESSAGE_DELIMITER + status);
     }
 
+    //Sensors are only used when player == currentPlayer
+    public void setSensorOn(boolean enabled) {
+        sensorOn = enabled;
+    }
     public void setDiceEnabled(boolean enabled){
 		btnWuerfel.setEnabled(enabled);
 	}
+    public void setRevealEnabled(boolean enabled){
+        btnAufdecken.setEnabled(enabled);
+    }
 }

--- a/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/structure/Cheat.java
+++ b/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/structure/Cheat.java
@@ -20,12 +20,13 @@ public class Cheat {
 
     public Cheat (){}
 
+    //Dient nur dem Würfel auf 6 bei Schummeln
     public void setPlayerCheating(boolean c){
         this.playerCheating = c;
-        //TODo unterscheidung ob vom Host oder Client bearbeitet? Wird in GamLogicHost&Client bearbeitet..
-        //informHost(c);
     }
 
+    //wird seperat aufgerufen in Spieleroberfläche wenn geschummelt wird und vom Host wenn neue Runde um wieder auf false zu setzen.
+    //-> Dient nur der Schummeln-Aufdecken funktion.
     public void informHost(boolean c){
         // host nachricht schicken
         GameLogic gameLogic = (GameLogic) DataHolder.getInstance().retrieve(Network.DATAHOLDER_GAMELOGIC);

--- a/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/structure/Cheat.java
+++ b/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/structure/Cheat.java
@@ -22,17 +22,17 @@ public class Cheat {
 
     public void setPlayerCheating(boolean c){
         this.playerCheating = c;
-        //für Testen ausgelagert und direkt in Spieleroberfläche aufgerufen (ToDo Sinnvoll?)
-        //sendMessageToHost();
+        //TODo unterscheidung ob vom Host oder Client bearbeitet? Wird in GamLogicHost&Client bearbeitet..
+        //informHost(c);
     }
 
-    public void informHost(){
+    public void informHost(boolean c){
         // host nachricht schicken
         GameLogic gameLogic = (GameLogic) DataHolder.getInstance().retrieve(Network.DATAHOLDER_GAMELOGIC);
         boolean isHost = gameLogic.isHost();
 
         if (!isHost){
-			((GameLogicClient) gameLogic).sendToHost(TAG_PLAYER_HAS_CHEATED + MESSAGE_DELIMITER + String.valueOf(true));
+			((GameLogicClient) gameLogic).sendToHost(TAG_PLAYER_HAS_CHEATED + MESSAGE_DELIMITER + String.valueOf(c));
         }
     }
 

--- a/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/structure/Player.java
+++ b/app/src/main/java/com/vintagetechnologies/menschaergeredichnicht/structure/Player.java
@@ -27,7 +27,8 @@ public class Player {
 	// if the player has to skip in the next round TODO: implement logic
     private boolean hasToSkip;
 
-
+    //if ture, player clicked during his turn.
+    private boolean clickerAktive;
     /**
      * creates a new Player Object with a specified PlayerColor and player name.
      * This constructor also creates the players GamePieces (fixed number: 4) and sets its other attributes.


### PR DESCRIPTION
Würfeln & Schummeln / Aufdecken wird je nach Status des Spielers de-/aktiviert.
Aufdecken ist ins Networking integriert: Wenn aufgedeck wird, wird das überprüft und allen Spielern ein Feedback gegeben ob geschummelt oder falsch verdächtigt wird. Für den jeweiligen spieler wird ein aussetzen boolean auf true gestetzt, die überprüfung -> das Aussetzen ist noch zu implementieren. 